### PR TITLE
Implement Dirichlet and Neumann boundary conditions

### DIFF
--- a/src/HallThruster.jl
+++ b/src/HallThruster.jl
@@ -15,6 +15,7 @@ include("limiters.jl")
 include("flux.jl")
 include("ionization.jl")
 include("geometry.jl")
+include("boundaryconditions.jl")
 include("simulation.jl")
 
 #dere

--- a/src/boundaryconditions.jl
+++ b/src/boundaryconditions.jl
@@ -1,0 +1,7 @@
+abstract type BoundaryCondition end
+
+struct Dirichlet  <: BoundaryCondition 
+    state::Vector{Float64}
+end
+
+struct Neumann <: BoundaryCondition end

--- a/src/boundaryconditions.jl
+++ b/src/boundaryconditions.jl
@@ -18,10 +18,10 @@ function apply_bc!(U, bc::Dirichlet, left_or_right::Symbol)
 end
 
 function apply_bc!(U, ::Neumann, left_or_right::Symbol)
-    if left_or_right == :right
-        @. @views U[begin, :] = U[begin, :]
-    elseif left_or_right == :left
-        @. @views U[end, :] = U[end, end-1]
+    if left_or_right == :left
+        @. @views U[:, begin] = U[:, begin+1]
+    elseif left_or_right == :right
+        @. @views U[:, end] = U[:, end-1]
     else
         throw(ArgumentError("left_or_right must be either :left or :right"))
     end

--- a/src/boundaryconditions.jl
+++ b/src/boundaryconditions.jl
@@ -1,7 +1,28 @@
 abstract type BoundaryCondition end
 
-struct Dirichlet  <: BoundaryCondition 
+struct Dirichlet  <: BoundaryCondition
     state::Vector{Float64}
 end
 
 struct Neumann <: BoundaryCondition end
+
+function apply_bc!(U, bc::Dirichlet, left_or_right::Symbol)
+    if left_or_right == :left
+        @. @views U[:, begin] = bc.state
+    elseif left_or_right == :right
+        @. @views U[:, end] = bc.state
+    else
+        throw(ArgumentError("left_or_right must be either :left or :right"))
+    end
+
+end
+
+function apply_bc!(U, ::Neumann, left_or_right::Symbol)
+    if left_or_right == :right
+        @. @views U[begin, :] = U[begin, :]
+    elseif left_or_right == :left
+        @. @views U[end, :] = U[end, end-1]
+    else
+        throw(ArgumentError("left_or_right must be either :left or :right"))
+    end
+end

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -47,12 +47,12 @@ function update!(dU, U, params, t)
 	nvariables = size(U, 1)
     ncells = size(U, 2) - 2
 
-	Te_index = nvariables-2
+	#=Te_index = nvariables-2
 	ne_index = nvariables-1
-	ϕ_index = nvariables
+	ϕ_index = nvariables=#
 
-    dU[:, 1] .= 0.0
-    dU[:, end] .= 0.0
+    apply_bc!(U, params.BCs[1], :left)
+    apply_bc!(U, params.BCs[2], :right)
 
     reconstruct!(UL, UR, U, scheme)
 	compute_fluxes!(F, UL, UR, fluids, fluid_ranges, scheme)
@@ -138,6 +138,7 @@ function run_simulation(sim)
     scheme = sim.scheme
 
     reactions = load_ionization_reactions(species)
+    BCs = sim.BCs
 
     params = (;
         cache,
@@ -148,7 +149,8 @@ function run_simulation(sim)
         z_edge,
         reactions,
         scheme,
-        mms
+        mms,
+        BCs
     )
 
     prob = ODEProblem{true}(update!, U, sim.tspan, params)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,7 +204,6 @@ scheme = (reconstruct = false, flux_function = upwind!, limiter = no_limiter)
 
 	F1_continuity = flux(U1[1:1], continuity_eq)[1]
 	F2_continuity = flux(U2[1:1], continuity_eq)[1]
-    @show F1_continuity, F2_continuity
 	F_continuity = hcat(F1_continuity, F1_continuity, F2_continuity)
 
 	F1_isothermal = flux(U1[2:3], isothermal_eq)[1:2] |> collect
@@ -216,9 +215,6 @@ scheme = (reconstruct = false, flux_function = upwind!, limiter = no_limiter)
 	F_euler = hcat(F1_euler, F2_euler, F2_euler)
 
 	F_expected = vcat(F_continuity, F_isothermal, F_euler)
-
-    @show F, size(F)
-    @show F_expected, size(F)
 
 	@testset "More flux tests" begin
 		@test UL_expected == UL

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -320,7 +320,8 @@ simulation = (
         limiter = identity,
         reconstruct = false
     ),
-    saveat = (0, 0.5e-3)
+    saveat = (0, 0.5e-3),
+    BCs = (HallThruster.Neumann(), HallThruster.Neumann())
 )
 
 using StaticArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -334,7 +334,6 @@ using StaticArrays
     @test HallThruster.find_left_index(1000, xs) == 100
     @test HallThruster.find_left_index(-1000, xs) == 0
 
-    
     xs = [1., 2.]
     ys = [1., 2.]
     ℓ = HallThruster.LinearInterpolation(xs, ys)
@@ -343,6 +342,24 @@ using StaticArrays
 
     ys = [1., 2., 3.]
     @test_throws(ArgumentError, HallThruster.LinearInterpolation(xs, ys))
+end
+
+@testset "Boundary condition tests" begin
+    BC1 = HallThruster.Dirichlet([1.0, 1.0, 1.0])
+    U = zeros(3, 5)
+    @test typeof(BC1) <: HallThruster.BoundaryCondition
+    HallThruster.apply_bc!(U, BC1, :left)
+    @test U[:, 1] == BC1.state
+    HallThruster.apply_bc!(U, BC1, :right)
+    @test U[:, end] == BC1.state
+    @test_throws(ArgumentError, HallThruster.apply_bc!(U, BC1, :not_left_or_right))
+
+    BC2 = HallThruster.Neumann()
+    HallThruster.apply_bc!(U, BC2, :left)
+    @test U[:, 1] == zeros(3)
+    HallThruster.apply_bc!(U, BC2, :right)
+    @test U[:, end] == zeros(3)
+    @test_throws(ArgumentError, HallThruster.apply_bc!(U, BC2, :not_left_or_right))
 end
 
 #begin

--- a/test/shock_tube.jl
+++ b/test/shock_tube.jl
@@ -6,6 +6,16 @@ function shock_tube(fluxfn, ncells, end_time)
 
     gas = HallThruster.Air
 
+    TL = pL / gas.R / ρL
+    TR = pR / gas.R / ρR
+
+    EL = gas.cv * TL
+    ER = gas.cv * TR
+
+    left_state = [0.0, ρL, ρL * uL, ρL * EL, 0.0, 0.0, 0.0]
+    right_state = [0.0, ρR, ρR * uR, ρR * ER, 0.0, 0.0, 0.0]
+
+    BCs = (HallThruster.Dirichlet(left_state), HallThruster.Dirichlet(right_state))
 
     L = 1.0
 
@@ -61,6 +71,7 @@ function shock_tube(fluxfn, ncells, end_time)
             limiter = identity,
             reconstruct = false
         ),
+        BCs = BCs
     )
 
     sol = HallThruster.run_simulation(simulation)


### PR DESCRIPTION
This will make boundary condition bookkeeping a bit easier. I defined some functions and types in boundaryconditions.jl as follows:

```julia
abstract type BoundaryCondition end

struct Dirichlet  <: BoundaryCondition
    state::Vector{Float64}
end

struct Neumann <: BoundaryCondition end

function apply_bc!(U, bc::Dirichlet, left_or_right::Symbol)
    if left_or_right == :left
        @. @views U[:, begin] = bc.state
    elseif left_or_right == :right
        @. @views U[:, end] = bc.state
    else
        throw(ArgumentError("left_or_right must be either :left or :right"))
    end

end

function apply_bc!(U, ::Neumann, left_or_right::Symbol)
    if left_or_right == :right
        @. @views U[begin, :] = U[begin, :]
    elseif left_or_right == :left
        @. @views U[end, :] = U[end, end-1]
    else
        throw(ArgumentError("left_or_right must be either :left or :right"))
    end
end
```

I also modified `update` to call these so we don't have to worry about what boundary conditions we're applying (for now). We'll need to implement more complex boundary conditions in the future.

All extant tests pass but I haven't touched the currently commented-out ones