### PR TITLE
MMS included for continuity and isothermal, works for runtests.jl

### DIFF
--- a/test/ovs_mms.jl
+++ b/test/ovs_mms.jl
@@ -12,49 +12,72 @@ mutable struct Result
 end
 
 function perform_OVS(; MMS_CONSTS, fluxfn, reconstruct)
+
+    source = mms!
     
-    simulation = (
-    ncells = 100,
-    propellant = HallThruster.Xenon,
-    ncharge = MMS_CONSTS.ncharge,
-    MMS = true,
-    mms! = mms!, 
-    cb = DiffEqCallbacks.TerminateSteadyState(1e-8, 1e-6, DiffEqCallbacks.allDerivPass),  #abstol, reltol, test
-    geometry = HallThruster.SPT_100,
-    neutral_temperature = 500.,
-    neutral_velocity = MMS_CONSTS.un,
-    ion_temperature = MMS_CONSTS.ion_temperature,
-    initial_nn_mms = nn_mms_func, 
-    initial_Te = Te_func,
-    initial_ϕ = ϕ_func,
-    initial_ni = ni_func,
-    solve_Te = false,
-    solve_ne = false,
-    inlet_mdot = 5e-6,
+    #need to somehow get the functions from runtests.jl to here
+    #think about how to integrate ICs and BCs such that no need to define quantities twice, often BCs will be similar to ICs.
+    #need information about fluid in BCs for certain quantities as well. 
+
+    function IC!(U, z, fluids, L)
+        gas1 = fluids[1].species.element
+        gas2 = fluids[2].species.element
+        #gas3 = fluids[3].species.element
+
+        ρ1 = 2000.0
+        ρ2 = 3000.0
+        u2 = 300.0
+        ρ3 = 5.0
+        u3 = 200.0
+        T3 = 300.0
+
+        U .= [ρ1, ρ2, ρ2*u2] #, ρ3, ρ3*u3, ρ3*T3*gas3.cv]
+        return U
+    end
+
+    ρ1 = 2000.0
+    ρ2 = 2000.0
+    u2 = 300.0
+    ρ3 = 5.0
+    u3 = 200.0
+    T3 = 300.0
+
+    left_state = [ρ1, ρ2, ρ2*u2] #, ρ3, ρ3*u3, ρ3*T3*HallThruster.Xenon.cv]
+    right_state = [ρ1, ρ2+1000, (ρ2+1000)*(u2+100)] #, ρ3, ρ3*u3, ρ3*T3*HallThruster.Xenon.cv]
+    BCs = (HallThruster.Dirichlet(left_state), HallThruster.Dirichlet(right_state))
+
+    simulation = HallThruster.MultiFluidSimulation(grid = HallThruster.generate_grid(HallThruster.SPT_100, MMS_CONSTS.n_cells_start), 
+    boundary_conditions = BCs,
+    scheme = HallThruster.HyperbolicScheme(fluxfn, HallThruster.minmod, reconstruct),
+    initial_condition = IC!, 
+    source_term! = source, 
+    fluids = [HallThruster.Fluid(HallThruster.Species(MMS_CONSTS.fluid, 0), HallThruster.ContinuityOnly(MMS_CONSTS.u_constant, MMS_CONSTS.T_constant));
+    HallThruster.Fluid(HallThruster.Species(MMS_CONSTS.fluid, 0), HallThruster.IsothermalEuler(MMS_CONSTS.T_constant))], #;
+    #HallThruster.Fluid(HallThruster.Species(MMS_CONSTS.fluid, 0), HallThruster.EulerEquations())], 
+    end_time = MMS_CONSTS.max_end_time, 
     saveat = [MMS_CONSTS.max_end_time],
-    tspan = (0., MMS_CONSTS.max_end_time),
-    dt = 200e-8, #5e-8
-    scheme = (
-        flux_function = fluxfn,
-        limiter = identity,
-        reconstruct = reconstruct
-        ),
+    timestepcontrol = (1e-6, false), #if adaptive true, given timestep ignored. Still sets initial timestep, therefore cannot be chosen arbitrarily large.
+    callback = DiffEqCallbacks.TerminateSteadyState(1e-8, 1e-6, DiffEqCallbacks.allDerivPass) 
     )
 
+    #generate different number of cells while keeping CFL number constant over refinements chosen
     refinements = MMS_CONSTS.refinements
     results = Array{Result, 1}(undef, refinements)
-    simulations_mms = Array{NamedTuple, 1}(undef, refinements)
+    simulations_mms = Array{HallThruster.MultiFluidSimulation, 1}(undef, refinements)
     n_cells = MMS_CONSTS.n_cells_start
     _, __, fluid_ranges, ___ = HallThruster.configure_simulation(simulation)
 
-    for refinement in 1:refinements
-        simulations_mms[refinement] = merge(simulation, (; ncells = n_cells, dt = MMS_CONSTS.CFL*MMS_CONSTS.L/(MMS_CONSTS.un*n_cells)))
+    for refinement in 1:refinements #set timestep and iterate number of cells
+        simulation.grid = HallThruster.generate_grid(HallThruster.SPT_100, n_cells)
+        simulation.timestepcontrol = (MMS_CONSTS.CFL*MMS_CONSTS.L/(MMS_CONSTS.u_constant*n_cells), false)
+        simulations_mms[refinement] = deepcopy(simulation)
         n_cells = n_cells*2
     end
-
+    
+    
     for refinement in 1:refinements
         sol = HallThruster.run_simulation(simulations_mms[refinement])
-        z_cells = HallThruster.generate_grid(simulation.geometry, simulations_mms[refinement].ncells)[1]
+        z_cells = simulations_mms[refinement].grid.cell_centers
         u_exa = Array{Union{Nothing, Float64}}(nothing, length(sol.u[1][:, 1]), length(z_cells))
         for (i, z_cell) in enumerate(z_cells)
             u_exa[1, i] = nn_manufactured_f(z_cell, MMS_CONSTS)
@@ -63,9 +86,9 @@ function perform_OVS(; MMS_CONSTS, fluxfn, reconstruct)
                 u_exa[index[2], i] = ni_manufactured_f(z_cell, MMS_CONSTS) * ui_manufactured_f(z_cell, MMS_CONSTS)
             end
         end
-        u_exa[end-2:end, :] .= 0.0
+        
         error = abs.(u_exa - sol.u[1])
-        results[refinement] = Result(sol, simulations_mms[refinement].dt, z_cells, simulations_mms[refinement].ncells, u_exa, error, [maximum(error[i, :]) for i in 1:size(error)[1]], [Statistics.mean(error[i, :]) for i in 1:size(error)[1]])
+        results[refinement] = Result(sol, simulations_mms[refinement].timestepcontrol[1], z_cells, simulations_mms[refinement].grid.ncells, u_exa, error, [maximum(error[i, :]) for i in 1:size(error)[1]], [Statistics.mean(error[i, :]) for i in 1:size(error)[1]])
     end
     return results
 end
@@ -79,9 +102,9 @@ function compute_slope(ncells, errors)
 end
 
 function evaluate_slope(results, MMS_CONSTS)
-    L_1 = Array{Union{Nothing, Float64}}(nothing, MMS_CONSTS.ncharge*2+1)
-    L_inf = Array{Union{Nothing, Float64}}(nothing, MMS_CONSTS.ncharge*2+1)
-    for j in 1:MMS_CONSTS.ncharge*2+1
+    L_1 = Array{Union{Nothing, Float64}}(nothing, 3)
+    L_inf = Array{Union{Nothing, Float64}}(nothing, 3)
+    for j in 1:3  ###need to rewrite this without ncharge terms
         L_1[j] = compute_slope([results[i].ncells for i in 1:length(results)], [results[i].L_1[j] for i in 1:length(results)])
         L_inf[j] = compute_slope([results[i].ncells for i in 1:length(results)], [results[i].L_inf[j] for i in 1:length(results)])
     end

--- a/test/shock_tube_v2.jl
+++ b/test/shock_tube_v2.jl
@@ -57,13 +57,15 @@ function shock_tube(fluxfn, ncells, end_time)
     #simulation input, need to somehow do initial conditions now as well, do as with boundary conditions in thomas code
     sim = HallThruster.MultiFluidSimulation(grid = HallThruster.generate_grid(geometry, ncells), 
     boundary_conditions = BCs,
-    scheme = HallThruster.HyperbolicScheme(fluxfn, HallThruster.minmod, true),
+    scheme = HallThruster.HyperbolicScheme(fluxfn, identity, false),
     initial_condition = IC!, 
     source_term! = source, 
     fluids = [HallThruster.Fluid(HallThruster.Species(HallThruster.Air, 0), HallThruster.EulerEquations());
     HallThruster.Fluid(HallThruster.Species(HallThruster.Air, 0), HallThruster.EulerEquations())], 
     end_time = end_time, 
-    saveat = [0, end_time]
+    saveat = [0, end_time],
+    timestepcontrol = (1e-6, true), #if adaptive true, given timestep ignored. Still sets initial timestep, therefore cannot be chosen arbitrarily large.
+    callback = nothing
     )
     sol = HallThruster.run_simulation(sim)
 end


### PR DESCRIPTION
updated source term handling in update.jl and added fields to MFS mutable struct. want to rewrite mms calcs to make use of the mutable struct, now creates copies, and add the euler equations, add HLLE and also with neumann BCs. need to think about some other manufactured solutions. should be straightforward. then add reconstruction as well.